### PR TITLE
* Update Sample project with C flag by value [-Wno-implicit-function-declaration] for fixing C99 issue. * Disable DEBUGGER_CONSTANT_USING_SPLIT_VIEW_IN_WORKSPACE constant for using popover instead of NSSplitView.

### DIFF
--- a/FlowarePopover-Sample/UI/Scenes/Home/HomeViewController.m
+++ b/FlowarePopover-Sample/UI/Scenes/Home/HomeViewController.m
@@ -905,7 +905,7 @@
 - (void)viewOpensGeneralView
 {
 #ifndef DEBUGGER_CONSTANT_USING_SPLIT_VIEW_IN_WORKSPACE
-    [self showGeneralPopupAtView:self.btnGeneral option:PopoverGeneralTypeTechnologies];
+    [self showGeneralPopupAtView:self.btnGeneral option:PopoverGeneralTypeComics];
 #else
     [self showViewInWorkspaceWithType:WorkspaceViewTypeComics];
 #endif

--- a/FlowarePopover-Sample/Utils/Constants.h
+++ b/FlowarePopover-Sample/Utils/Constants.h
@@ -61,7 +61,7 @@
 /// FLOPopover popup
 /// or
 /// contentSplitView in workspace.
-#define DEBUGGER_CONSTANT_USING_SPLIT_VIEW_IN_WORKSPACE
+//#define DEBUGGER_CONSTANT_USING_SPLIT_VIEW_IN_WORKSPACE
 
 ///
 /// Entitlements Identifiers

--- a/FlowarePopover.xcodeproj/project.pbxproj
+++ b/FlowarePopover.xcodeproj/project.pbxproj
@@ -1502,6 +1502,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/FlowarePopover-Sample/Supporting-Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				OTHER_CFLAGS = "-Wno-implicit-function-declaration";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.floware.FlowarePopover-Sample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/FlowarePopover/Classes";
@@ -1520,6 +1521,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/FlowarePopover-Sample/Supporting-Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				OTHER_CFLAGS = "-Wno-implicit-function-declaration";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.floware.FlowarePopover-Sample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/FlowarePopover/Classes";


### PR DESCRIPTION
* Update Sample project with C flag by value [-Wno-implicit-function-declaration] for fixing C99 issue.
* Disable DEBUGGER_CONSTANT_USING_SPLIT_VIEW_IN_WORKSPACE constant for using popover instead of NSSplitView.